### PR TITLE
Feature add support for forwarding logs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
   notify: Restart rsyslog
 
 - name: Check which init system is in place
-  shell: cat /proc/1/status | grep '[Nn]ame'|sed 's/[Nn]ame:\s*//'a # noqa 306
+  shell: cat /proc/1/status | grep '[Nn]ame'|sed 's/[Nn]ame:\s*//' # noqa 306
   register: init_system
   changed_when: false
 

--- a/templates/22-rsyslog.conf.j2
+++ b/templates/22-rsyslog.conf.j2
@@ -21,8 +21,8 @@ $ActionResumeRetryCount {{ rsyslog_action_resume_retry_count }}
 
 {% if rsyslog_tls %}$DefaultNetstreamDriverCAFile {{ rsyslog_cert_path }}/{{ rsyslog_cert }}{% endif %}
 
-template(name="loggly.com" type="string" string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% {{ inventory_hostname }} %app-name% %procid% %msgid% [{{ rsyslog_token }}@41058 {% if rsyslog_tag %}tag=\"{{ rsyslog_tag }}\"{% endif %}] %msg%\n")
-template(name="logz.io" type="string" string="[{{ rsyslog_token }}] <%pri%>%protocol-version% %timestamp:::date-rfc3339% {{ inventory_hostname }} %app-name% %procid% %msgid% %msg%\n")
+template(name="loggly.com" type="string" string="<%pri%>%protocol-version% %timestamp:::date-rfc3339% %hostname% %app-name% %procid% %msgid% [{{ rsyslog_token }}@41058 {% if rsyslog_tag %}tag=\"{{ rsyslog_tag }}\"{% endif %}] %msg%\n")
+template(name="logz.io" type="string" string="[{{ rsyslog_token }}] <%pri%>%protocol-version% %timestamp:::date-rfc3339% %hostname% %app-name% %procid% %msgid% %msg%\n")
 
 # Send messages over TCP using the template.
 {% if rsyslog_tls %}


### PR DESCRIPTION
* fixes what I presume was a typo on main.yml

The error I was getting was the following:
```
TASK [papanito.rsyslog : Check which init system is in place] ***********************************************************************************************************************************************************************************************************
fatal: [logs-forwarder.local]: FAILED! => {"changed": false, "cmd": "cat /proc/1/status | grep '[Nn]ame'|sed 's/[Nn]ame:\\s*//'a", "delta": "0:00:00.019759", "end": "2020-08-01 17:36:57.705686", "msg": "non-zero return code", "rc": 1, "start": "2020-08-01 17:36:57.685927", "stderr": "sed: -e expression #1, char 16: unknown option to `s'", "stderr_lines": ["sed: -e expression #1, char 16: unknown option to `s'"], "stdout": "", "stdout_lines": []}
```

* makes it so that %hostname% is used instead of the ansible hostname... this allows you use a host as a forwarder. 

ex:
vars.yml
```
rsyslog_additional_config:
  - $ModLoad imudp
  - $UDPServerAddress 0.0.0.0 # listen on the localhost , protocol UDP
  - $UDPServerRun 514 # listen on port 514, protocol UDP
```

```
echo '<14>myhostnametest message text' | nc -v -u -w 5 logs-forwarder.local 514
#myhostnametest is set as the hostname in logz.io instead of logs-forwarder.local
```
It keeps the behavior the same assuming that %hostname% of the system is the same as inventory_hostname (and you didnt override inventory_hostname) 
